### PR TITLE
Add nestedtext-ruby link in related_projects.rst

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -29,6 +29,12 @@ Implementations
 (supports :ref:`NestedText v3.0 <v3.0>`).
 
 
+`nestedtext-ruby <https://github.com/erikw/nestedtext-ruby>`_
+"""""""""""""""""""""""""""""""""""""""""""""""""
+`Ruby <https://www.ruby-lang.org/en/>`_ implementation of *NestedText*
+(supports :ref:`NestedText v3.1 <v3.1>`).
+
+
 `janet-nested-text <https://github.com/andrewchambers/janet-nested-text>`_
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 `Janet <https://janet-lang.org/>`_ implementation of *NestedText*


### PR DESCRIPTION
Adding a link to [nestedtext-ruby](https://github.com/erikw/nestedtext-ruby).

While there are still tons of code improvements and features that I would like to add, it's already usable and released to rubygems.org! All official tests are passing ✅ 

I will contribute with my Ruby helper for the official tests too, once I've cleaned up the code with linters and so on

https://github.com/erikw/nestedtext_tests/blob/add_ruby_api/api/nestedtext_official_tests.rb