### PR TITLE
whitespace, again

### DIFF
--- a/doc/file_format.rst
+++ b/doc/file_format.rst
@@ -185,8 +185,8 @@ The *NestedText* format follows a small number of simple rules. Here they are.
     Specifically, inline strings may not contain newlines or any of the 
     following characters: ``[``, ``]``, ``{``, ``}``, or ``,``.  In addition, 
     inline strings that are contained in inline dictionaries may not contain 
-    ``:``.  Both leading and trailing ASCII spaces and ASCII tabs are ignored
-    with inline strings.
+    ``:``.  Both leading and trailing ASCII spaces are ignored with inline
+    strings.
 
     Both inline lists and dictionaries may be empty, and represent the only way 
     to represent empty lists or empty dictionaries in *NestedText*.  An empty 

--- a/doc/file_format.rst
+++ b/doc/file_format.rst
@@ -123,8 +123,8 @@ The *NestedText* format follows a small number of simple rules. Here they are.
     The first is a *dictionary item with inline key*.  In this case the line 
     starts with a key followed by a dictionary tag: a colon followed by either 
     an ASCII space (``:␣``) or a newline.  The dictionary item consists of the 
-    key, the tag, and the trailing value.  Any Unicode white-space between the 
-    key and the tag is ignored.
+    key, the tag, and the trailing value.  Any ASCII spaces between the key and
+    the tag is ignored.
 
     The inline key precedes the tag. It must be a non-empty string and must not:
 
@@ -132,8 +132,8 @@ The *NestedText* format follows a small number of simple rules. Here they are.
     #. start with a list item, string item or key item tag,
     #. start with ``[`` or ``{``,
     #. contain a dictionary item tag, or
-    #. contain Unicode leading spaces
-       (any Unicode spaces that follow the key are ignored).
+    #. contain leading ASCII spaces
+       (any ASCII spaces that follow the key are ignored).
 
     The tag is only used to determine the type of the line and is discarded 
     leaving the key and the value, which follows the tag.  The value takes one 

--- a/doc/file_format.rst
+++ b/doc/file_format.rst
@@ -68,7 +68,7 @@ The *NestedText* format follows a small number of simple rules. Here they are.
 
 **String items**:
 
-    If the first non-space character on a line is a greater-than symbol followed 
+    If the first non-ASCII-space character on a line is a greater-than symbol followed 
     immediately by an ASCII space (``>␣``) or a line break, the line is a *string 
     item*.  After comments and blank lines have been removed, adjacent string 
     items with the same indentation level are combined in order into 
@@ -81,7 +81,7 @@ The *NestedText* format follows a small number of simple rules. Here they are.
 
 **List items**:
 
-    If the first non-space character on a line is a dash followed immediately by 
+    If the first non-ASCII-space character on a line is a dash followed immediately by 
     an ASCII space (``-␣``) or a line break, the line is a *list item*.  
     Adjacent list items with the same indentation level are combined in order 
     into a list.  Each list item has a tag and a value.  The tag is only used to 


### PR DESCRIPTION
What are your thoughts on further hardening the specification? What part of the spec needs unicode whitespace, or tab characters?