### PR TITLE
Add Java implementation of Minimal NestedText to related projects

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -49,6 +49,16 @@ Janet
 Supports :ref:`NestedText v3.0 <v3.0>`.
 
 
+Java
+"""""
+
+`nestedtext-min-java <https://github.com/loxlylabs/nestedtext-min-java>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+`Java <https://www.java.com/>`_ implementation of *Minimal NestedText*.
+Supports :ref:`Minimal NestedText v3.7 <v3.7>`.
+
+
 JavaScript
 """"""""""
 


### PR DESCRIPTION
Added a link to [nestedtext-min-java](https://github.com/loxlylabs/nestedtext-min-java) in the related projects section.

It's passing all the new proposed tests (excluding tests which are not part of minimal nestedtext) with the exception of two tests mentioned here: https://github.com/KenKundert/nestedtext/issues/58#issuecomment-3257100595

I was looking for an ideal text format for declaring policies for an authorization library I'm working and NestedText seemed like the perfect fit, but there was no official Java implementation. The Minimal subset is sufficient and in some ways easier to understand for the users who will be authorizing these files. Thanks for the great format!
