### PR TITLE
Add Go nestedtext implementation and fix nestext details

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -37,11 +37,17 @@ Supports :ref:`Minimal NestedText v3.7 <v3.7>`.
 Go
 ""
 
-`nestex <https://github.com/npillmayer/nestext>`_
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`nestedtext <https://github.com/danielledeleo/nestedtext>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+`Go <https://golang.org/>`_ implementation of *NestedText* with idiomatic API.
+Supports :ref:`NestedText v3.8 <v3.8>`.
+
+`nestext <https://github.com/npillmayer/nestext>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 `Go <https://golang.org/>`_ implementation of *NestedText*.
-Supports :ref:`NestedText v3.0 <v3.0>`.
+Supports :ref:`NestedText v3.1 <v3.1>`.
 
 
 Janet


### PR DESCRIPTION
Submitting this PR to add my fork of [npillmayer/nestext](https://github.com/npillmayer/nestext). It has a substantially different API (more idiomatic Go, matching similar JSON/YAML libraries).

- Add danielledeleo/nestedtext: Go implementation with idiomatic API supporting NestedText v3.8
- Fix typo: nestex → nestext
- Update nestext version support to v3.1